### PR TITLE
Allow multiple settings objects to be used within a single page

### DIFF
--- a/vendor/assets/javascripts/markitup/sets/bbcode/set.js
+++ b/vendor/assets/javascripts/markitup/sets/bbcode/set.js
@@ -9,7 +9,7 @@
 // ----------------------------------------------------------------------------
 // Feel free to add more tags
 // ----------------------------------------------------------------------------
-mySettings = {
+mySettings = bbcodeSettings = {
 	previewParserPath: "/markitup/preview", // path to your BBCode parser
 	markupSet: [
 		{name:'Bold', key:'B', openWith:'[b]', closeWith:'[/b]'},

--- a/vendor/assets/javascripts/markitup/sets/css/set.js
+++ b/vendor/assets/javascripts/markitup/sets/css/set.js
@@ -11,7 +11,7 @@
 // ----------------------------------------------------------------------------
 // Basic CSS set. Feel free to add more tags
 // ----------------------------------------------------------------------------
-mySettings = {
+mySettings = cssSettings = {
 	onEnter:			{},
 	onShiftEnter:		{keepDefault:false, placeHolder:'Your comment here', openWith:'\n\/* ', closeWith:' *\/'},
 	onCtrlEnter:		{keepDefault:false, placeHolder:"classname", openWith:'\n.', closeWith:' { \n'},

--- a/vendor/assets/javascripts/markitup/sets/dotclear/set.js
+++ b/vendor/assets/javascripts/markitup/sets/dotclear/set.js
@@ -8,7 +8,7 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
+mySettings = dotclearSettings = {
 	previewParserPath: "/markitup/preview", // path to your DotClear parser
 	onShiftEnter:		{keepDefault:false, replaceWith:'%%%\n'},
 	onCtrlEnter:		{keepDefault:false, replaceWith:'\n\n'},

--- a/vendor/assets/javascripts/markitup/sets/html/set.js
+++ b/vendor/assets/javascripts/markitup/sets/html/set.js
@@ -9,7 +9,7 @@
 // ----------------------------------------------------------------------------
 // Basic set. Feel free to add more tags
 // ----------------------------------------------------------------------------
-mySettings = {
+mySettings = htmlSettings = {
 	onShiftEnter:	{keepDefault:false, replaceWith:'<br />\n'},
 	onCtrlEnter:	{keepDefault:false, openWith:'\n<p>', closeWith:'</p>\n'},
 	onTab:			{keepDefault:false, openWith:'	 '},

--- a/vendor/assets/javascripts/markitup/sets/markdown/set.js
+++ b/vendor/assets/javascripts/markitup/sets/markdown/set.js
@@ -10,7 +10,7 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
+mySettings = markdownSettings = {
 	previewParserPath: "/markitup/preview",
 	onShiftEnter:		{keepDefault:false, openWith:'\n\n'},
 	markupSet: [

--- a/vendor/assets/javascripts/markitup/sets/markmin/set.js
+++ b/vendor/assets/javascripts/markitup/sets/markmin/set.js
@@ -11,7 +11,7 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
+mySettings = markminSettings = {
 	previewParserPath: "/markitup/preview",
 	onShiftEnter:		{keepDefault:false, openWith:'\n\n'},
 	markupSet: [

--- a/vendor/assets/javascripts/markitup/sets/rest/set.js
+++ b/vendor/assets/javascripts/markitup/sets/rest/set.js
@@ -12,7 +12,7 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
+mySettings = restSettings = {
 	previewParserPath: "/markitup/preview",
 	onShiftEnter:		{keepDefault:false, replaceWith:'\n\n'},
 	markupSet: [

--- a/vendor/assets/javascripts/markitup/sets/textile/set.js
+++ b/vendor/assets/javascripts/markitup/sets/textile/set.js
@@ -10,7 +10,7 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
+mySettings = textileSettings = {
 	previewParserPath: "/markitup/preview",
 	onShiftEnter:		{keepDefault:false, replaceWith:'\n\n'},
 	markupSet: [

--- a/vendor/assets/javascripts/markitup/sets/texy/set.js
+++ b/vendor/assets/javascripts/markitup/sets/texy/set.js
@@ -11,7 +11,7 @@
 // http://texy.info
 // Feel free to do anything with this.
 // -------------------------------------------------------------------
-mySettings = {	
+mySettings = texySettings = {	
 	previewParserPath: "/markitup/preview",
 	onShiftEnter:	    {keepDefault:false, replaceWith:'\n\n'},
 	markupSet: [	 

--- a/vendor/assets/javascripts/markitup/sets/txt2tags/set.js
+++ b/vendor/assets/javascripts/markitup/sets/txt2tags/set.js
@@ -11,7 +11,7 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
+mySettings = txt2tagsSettings = {
 	previewParserPath: "/markitup/preview", // path to your Txt2tags parser
 	onShiftEnter:		{keepDefault:false, replaceWith:'\n\n'},
 	markupSet: [

--- a/vendor/assets/javascripts/markitup/sets/wiki/set.js
+++ b/vendor/assets/javascripts/markitup/sets/wiki/set.js
@@ -8,7 +8,7 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
+mySettings = wikiSettings = {
 	previewParserPath: "/markitup/preview", // path to your Wiki parser
 	onShiftEnter:		{keepDefault:false, replaceWith:'\n\n'},
 	markupSet: [

--- a/vendor/assets/javascripts/markitup/sets/xbbcode/set.js
+++ b/vendor/assets/javascripts/markitup/sets/xbbcode/set.js
@@ -4,7 +4,7 @@
 // Copyright (C) 2008 Jay Salvat
 // http://markitup.jaysalvat.com/
 // ----------------------------------------------------------------------------
-mySettings = {
+mySettings = xbbcodeSettings = {
   nameSpace: "xbbcode", // Useful to prevent multi-instances CSS conflict
 	previewParserPath: "/markitup/preview", // path to your XBBCode parser
 	onShiftEnter:	{keepDefault:false, replaceWith:'[br /]\n'},


### PR DESCRIPTION
I've added set-specific variable names for each of the settings objects. When you include multiple sets in your application.js file, this change allows you to differentiate between the settings objects. This is necessary when you want to have multiple MarkItUp editors on a single page, each using different sets.

(This is a backwards-compatible change: I've left the existing "mySettings" variables in place.)

The only downside I can see is that, if and when this gem needs to be upgraded with new set files, these changes will need to be re-applied. I consider this useful enough to be worth that overhead; hopefully you do too.
